### PR TITLE
fix(web): insert slash before username in user-edit form action

### DIFF
--- a/go/web/public/js/user-edit.js
+++ b/go/web/public/js/user-edit.js
@@ -1,6 +1,7 @@
 $(() => {
 	var target = base_url + 'admin/user/edit';
-	if (username) target += username;
+	// Must be /admin/user/edit/{username} — without slash becomes /admin/user/editadmin (404).
+	if (username) target += '/' + username;
 	$('form').attr('action', target);
 	if (error) alert('danger', error);
 });


### PR DESCRIPTION
Without '/', editing user "admin" posted to /admin/user/editadmin and returned 404.