### PR TITLE
chore: add git-ship-pr and git-merge-cleanup skills

### DIFF
--- a/.agents/skills/git-merge-cleanup/SKILL.md
+++ b/.agents/skills/git-merge-cleanup/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: git-merge-cleanup
+description: "Merge a GitHub PR (or confirm already merged), delete the feature branch, checkout main, and sync local. Use when user says merge the PR, PR merged clean up, switch back to main and delete the feat branch."
+---
+
+# Git Merge + Cleanup
+
+After a feature PR is ready or already merged: merge if needed, delete the feature branch, return local repo to updated `main`.
+
+**Does not** implement features or open PRs. For ship/PR creation use `git-ship-pr`. For Trellis archive/journal use `trellis-finish-work` (usually already done on the feature branch before merge).
+
+## When to use
+
+- User: "merged, switch back to main and delete the feat branch"
+- User: "merge the PR, delete branch, back to main"
+- User: "are you able to merge the pr and clean up"
+
+## Step 1: Identify PR and branch
+
+```bash
+git branch --show-current
+git status --porcelain
+gh pr status
+# or explicit:
+gh pr view <number> --json number,state,mergeable,headRefName,baseRefName,url,title
+```
+
+If user said "merged" without a number, resolve the latest PR for the current branch or the branch they named:
+
+```bash
+gh pr list --head "<branch>" --state all --limit 1
+```
+
+If the working tree is dirty with unrelated changes, warn and ask before `reset --hard` / checkout.
+
+## Step 2: Merge (if still open)
+
+```bash
+gh pr view <n> --json state,mergeable,title,url
+```
+
+| State | Action |
+|-------|--------|
+| `OPEN` + mergeable | `gh pr merge <n> --merge --delete-branch` (or `--squash` if user prefers) |
+| `OPEN` + not mergeable | Report conflicts; stop |
+| `MERGED` | Skip merge; still do local cleanup |
+| `CLOSED` unmerged | Report; do not pretend success |
+
+Default merge method: **merge commit** (`--merge`), matching this repo’s recent PR history. Use `--squash` only if user asks.
+
+`--delete-branch` deletes the **remote** head branch when supported.
+
+## Step 3: Local main sync
+
+```bash
+git fetch --prune origin
+git checkout main
+git pull --ff-only origin main
+```
+
+If pull fails due to ref lock / non-ff:
+
+```bash
+git fetch origin main
+git checkout main
+git reset --hard origin/main
+```
+
+Only use `reset --hard` when the user wants a clean match to remote and there is no precious local-only work on `main`.
+
+## Step 4: Delete local feature branch
+
+```bash
+git branch -d <feature-branch> 2>/dev/null || git branch -D <feature-branch>
+```
+
+- Prefer `-d` (safe). Use `-D` only if branch is unmerged and user confirms discard.
+- If branch already gone (`not found`), continue.
+
+Remote delete if still present and not removed by `gh pr merge --delete-branch`:
+
+```bash
+git push origin --delete <feature-branch> 2>/dev/null || true
+```
+
+"remote ref does not exist" is OK.
+
+## Step 5: Verify
+
+```bash
+git status
+git branch --show-current
+git log --oneline -5
+git branch -a | grep <feature-slug> || echo "feature branch gone"
+```
+
+Expect:
+
+- On `main`
+- Clean working tree (unless user had other WIP)
+- In sync with `origin/main`
+- Feature branch absent locally (and preferably remotely)
+
+## Step 6: Report
+
+```text
+PR: <url> → MERGED
+Local: main @ <short-hash>
+Branches removed: <name> (local/remote)
+```
+
+Optional: if a parent Trellis task is complete (all children archived), mention they can archive the parent with `task.py archive` — do not auto-archive parents unless user asks.
+
+## Anti-patterns
+
+- Merging without checking `mergeable` / CI when user did not waive checks
+- `reset --hard` with uncommitted user work
+- Deleting `main`
+- Leaving local feature branch after "clean up" when delete was requested
+- Creating a new Trellis task for merge cleanup (simple ops; no task unless user wants one)

--- a/.agents/skills/git-ship-pr/SKILL.md
+++ b/.agents/skills/git-ship-pr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: git-ship-pr
+description: "Ship work: ensure feature branch, confirm commit plan, commit, push, open GitHub PR. Use when user says ship, open PR, commit and push, create PR, or 'ok close the task and create PR'."
+---
+
+# Git Ship + Open PR
+
+Turn finished local work into a remote branch and a GitHub pull request.
+
+**Does not** merge the PR or archive Trellis tasks. After merge, use `git-merge-cleanup`. For Trellis archive/journal only, use `trellis-finish-work` (after code is committed).
+
+## When to use
+
+- User asks to commit + push + create PR
+- User says "ok close the task in the same branch and create PR"
+- End of Phase 3.4 when the plan includes shipping, not only local commit
+
+## Preconditions
+
+- User confirmed the commit plan (or explicitly said `ok` / `行` to a presented plan)
+- Quality checks already run when this is a Trellis task (typecheck/tests as applicable)
+- Do **not** commit secrets; do **not** amend/force-push unless user explicitly asks
+
+## Step 1: Inspect git state
+
+```bash
+git status --porcelain
+git branch --show-current
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true
+git log --oneline -5
+git diff --stat
+```
+
+Classify dirty paths:
+
+| Kind | Action |
+|------|--------|
+| This task / this request | Include in commit plan |
+| Unrelated WIP | Exclude; list as "not in commits" |
+| Already clean | Skip commit; still may push + PR if branch is ahead |
+
+## Step 2: Ensure feature branch
+
+If current branch is `main` or `master` (or the default base) **and** there are commits or dirty files to ship:
+
+```bash
+git checkout -b <branch>
+```
+
+Branch naming (prefer project style from recent branches):
+
+- `feat/<short-slug>`
+- `fix/<short-slug>`
+- `refactor/<short-slug>`
+- `chore/<short-slug>`
+
+If already on a feature branch, **keep it** (do not create a nested branch).
+
+If the branch name is wrong for the change set, rename with user agreement:
+
+```bash
+git branch -m <new-name>
+```
+
+## Step 3: Commit plan (one-shot confirmation)
+
+Learn message style from `git log --oneline -5`.
+
+Group files into 1+ logical commits (not one commit per file). Present:
+
+```text
+Branch: <name> (create / already on)
+
+Proposed commits (in order):
+  1. <message>
+     - <file>
+  2. <message>
+     - <file>
+
+Excluded (not this work):
+  - <file>
+
+Reply 'ok' / '行' to execute. Edits or 'manual' to abort.
+```
+
+On rejection / `manual`: stop. Do not invent a second full plan unless the user asks.
+
+If the user already said `ok` to a plan in the previous turn, execute without re-asking.
+
+## Step 4: Commit
+
+For each planned commit:
+
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<message>
+
+<optional body>
+EOF
+)"
+```
+
+Rules:
+
+- No `--amend` unless user explicitly requests
+- No empty commits
+- Prefer HEREDOC for multi-line messages
+- After Trellis archive/journal auto-commits, those are separate commits (see optional Step 6)
+
+## Step 5: Push and create PR
+
+```bash
+git push -u origin HEAD
+```
+
+Then create PR against the base branch (usually `main`):
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet>
+
+## Test plan
+- [ ] <check>
+EOF
+)"
+```
+
+- Title usually matches the primary work commit subject
+- Body: summary + test plan (commands already run + manual checks)
+- Return the PR URL to the user
+
+If `gh` is unavailable, print the compare URL from `git push` remote output and stop.
+
+## Step 6 (optional): Trellis close-out on same branch
+
+Only when user asked to close the Trellis task **and** ship:
+
+1. Code commits first (Steps 4–5 work commits may already be done)
+2. `python3 ./.trellis/scripts/task.py archive <task-dir-or-name>`
+3. `python3 ./.trellis/scripts/add_session.py --title "..." --commit "<work-hashes>" --summary "..."`  
+   - Use **work** commit hashes only (not archive/journal hashes)
+4. `git push` again so archive/journal commits land on the remote branch
+5. If PR already exists, no need to recreate; push updates the PR
+
+If user only wants PR and will archive later, skip this step.
+
+## Step 7: Report
+
+```text
+Branch: <name>
+Commits: <hashes + subjects>
+PR: <url>
+```
+
+## Anti-patterns
+
+- Committing on `main` without user saying so
+- Shipping unrelated dirty files silently
+- Force-push / amend by default
+- Creating a PR with no push
+- Archiving Trellis before code commits when the tree still has task code changes

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,23 @@
 /go/mango
 /node_modules/
 
-.agents/
+# Platform agent dirs (local); re-include tracked git ship/merge skills.
+.agents/*
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/git-ship-pr/
+!.agents/skills/git-ship-pr/**
+!.agents/skills/git-merge-cleanup/
+!.agents/skills/git-merge-cleanup/**
 .claude/
 .codex/
-.opencode/
+.opencode/*
+!.opencode/skills/
+.opencode/skills/*
+!.opencode/skills/git-ship-pr/
+!.opencode/skills/git-ship-pr/**
+!.opencode/skills/git-merge-cleanup/
+!.opencode/skills/git-merge-cleanup/**
 AGENTS.md
 
 # Trellis: track tasks/specs/workspace; ignore local runtime noise

--- a/.opencode/skills/git-merge-cleanup/SKILL.md
+++ b/.opencode/skills/git-merge-cleanup/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: git-merge-cleanup
+description: "Merge a GitHub PR (or confirm already merged), delete the feature branch, checkout main, and sync local. Use when user says merge the PR, PR merged clean up, switch back to main and delete the feat branch."
+---
+
+# Git Merge + Cleanup
+
+After a feature PR is ready or already merged: merge if needed, delete the feature branch, return local repo to updated `main`.
+
+**Does not** implement features or open PRs. For ship/PR creation use `git-ship-pr`. For Trellis archive/journal use `trellis-finish-work` (usually already done on the feature branch before merge).
+
+## When to use
+
+- User: "merged, switch back to main and delete the feat branch"
+- User: "merge the PR, delete branch, back to main"
+- User: "are you able to merge the pr and clean up"
+
+## Step 1: Identify PR and branch
+
+```bash
+git branch --show-current
+git status --porcelain
+gh pr status
+# or explicit:
+gh pr view <number> --json number,state,mergeable,headRefName,baseRefName,url,title
+```
+
+If user said "merged" without a number, resolve the latest PR for the current branch or the branch they named:
+
+```bash
+gh pr list --head "<branch>" --state all --limit 1
+```
+
+If the working tree is dirty with unrelated changes, warn and ask before `reset --hard` / checkout.
+
+## Step 2: Merge (if still open)
+
+```bash
+gh pr view <n> --json state,mergeable,title,url
+```
+
+| State | Action |
+|-------|--------|
+| `OPEN` + mergeable | `gh pr merge <n> --merge --delete-branch` (or `--squash` if user prefers) |
+| `OPEN` + not mergeable | Report conflicts; stop |
+| `MERGED` | Skip merge; still do local cleanup |
+| `CLOSED` unmerged | Report; do not pretend success |
+
+Default merge method: **merge commit** (`--merge`), matching this repo’s recent PR history. Use `--squash` only if user asks.
+
+`--delete-branch` deletes the **remote** head branch when supported.
+
+## Step 3: Local main sync
+
+```bash
+git fetch --prune origin
+git checkout main
+git pull --ff-only origin main
+```
+
+If pull fails due to ref lock / non-ff:
+
+```bash
+git fetch origin main
+git checkout main
+git reset --hard origin/main
+```
+
+Only use `reset --hard` when the user wants a clean match to remote and there is no precious local-only work on `main`.
+
+## Step 4: Delete local feature branch
+
+```bash
+git branch -d <feature-branch> 2>/dev/null || git branch -D <feature-branch>
+```
+
+- Prefer `-d` (safe). Use `-D` only if branch is unmerged and user confirms discard.
+- If branch already gone (`not found`), continue.
+
+Remote delete if still present and not removed by `gh pr merge --delete-branch`:
+
+```bash
+git push origin --delete <feature-branch> 2>/dev/null || true
+```
+
+"remote ref does not exist" is OK.
+
+## Step 5: Verify
+
+```bash
+git status
+git branch --show-current
+git log --oneline -5
+git branch -a | grep <feature-slug> || echo "feature branch gone"
+```
+
+Expect:
+
+- On `main`
+- Clean working tree (unless user had other WIP)
+- In sync with `origin/main`
+- Feature branch absent locally (and preferably remotely)
+
+## Step 6: Report
+
+```text
+PR: <url> → MERGED
+Local: main @ <short-hash>
+Branches removed: <name> (local/remote)
+```
+
+Optional: if a parent Trellis task is complete (all children archived), mention they can archive the parent with `task.py archive` — do not auto-archive parents unless user asks.
+
+## Anti-patterns
+
+- Merging without checking `mergeable` / CI when user did not waive checks
+- `reset --hard` with uncommitted user work
+- Deleting `main`
+- Leaving local feature branch after "clean up" when delete was requested
+- Creating a new Trellis task for merge cleanup (simple ops; no task unless user wants one)

--- a/.opencode/skills/git-ship-pr/SKILL.md
+++ b/.opencode/skills/git-ship-pr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: git-ship-pr
+description: "Ship work: ensure feature branch, confirm commit plan, commit, push, open GitHub PR. Use when user says ship, open PR, commit and push, create PR, or 'ok close the task and create PR'."
+---
+
+# Git Ship + Open PR
+
+Turn finished local work into a remote branch and a GitHub pull request.
+
+**Does not** merge the PR or archive Trellis tasks. After merge, use `git-merge-cleanup`. For Trellis archive/journal only, use `trellis-finish-work` (after code is committed).
+
+## When to use
+
+- User asks to commit + push + create PR
+- User says "ok close the task in the same branch and create PR"
+- End of Phase 3.4 when the plan includes shipping, not only local commit
+
+## Preconditions
+
+- User confirmed the commit plan (or explicitly said `ok` / `行` to a presented plan)
+- Quality checks already run when this is a Trellis task (typecheck/tests as applicable)
+- Do **not** commit secrets; do **not** amend/force-push unless user explicitly asks
+
+## Step 1: Inspect git state
+
+```bash
+git status --porcelain
+git branch --show-current
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true
+git log --oneline -5
+git diff --stat
+```
+
+Classify dirty paths:
+
+| Kind | Action |
+|------|--------|
+| This task / this request | Include in commit plan |
+| Unrelated WIP | Exclude; list as "not in commits" |
+| Already clean | Skip commit; still may push + PR if branch is ahead |
+
+## Step 2: Ensure feature branch
+
+If current branch is `main` or `master` (or the default base) **and** there are commits or dirty files to ship:
+
+```bash
+git checkout -b <branch>
+```
+
+Branch naming (prefer project style from recent branches):
+
+- `feat/<short-slug>`
+- `fix/<short-slug>`
+- `refactor/<short-slug>`
+- `chore/<short-slug>`
+
+If already on a feature branch, **keep it** (do not create a nested branch).
+
+If the branch name is wrong for the change set, rename with user agreement:
+
+```bash
+git branch -m <new-name>
+```
+
+## Step 3: Commit plan (one-shot confirmation)
+
+Learn message style from `git log --oneline -5`.
+
+Group files into 1+ logical commits (not one commit per file). Present:
+
+```text
+Branch: <name> (create / already on)
+
+Proposed commits (in order):
+  1. <message>
+     - <file>
+  2. <message>
+     - <file>
+
+Excluded (not this work):
+  - <file>
+
+Reply 'ok' / '行' to execute. Edits or 'manual' to abort.
+```
+
+On rejection / `manual`: stop. Do not invent a second full plan unless the user asks.
+
+If the user already said `ok` to a plan in the previous turn, execute without re-asking.
+
+## Step 4: Commit
+
+For each planned commit:
+
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<message>
+
+<optional body>
+EOF
+)"
+```
+
+Rules:
+
+- No `--amend` unless user explicitly requests
+- No empty commits
+- Prefer HEREDOC for multi-line messages
+- After Trellis archive/journal auto-commits, those are separate commits (see optional Step 6)
+
+## Step 5: Push and create PR
+
+```bash
+git push -u origin HEAD
+```
+
+Then create PR against the base branch (usually `main`):
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet>
+
+## Test plan
+- [ ] <check>
+EOF
+)"
+```
+
+- Title usually matches the primary work commit subject
+- Body: summary + test plan (commands already run + manual checks)
+- Return the PR URL to the user
+
+If `gh` is unavailable, print the compare URL from `git push` remote output and stop.
+
+## Step 6 (optional): Trellis close-out on same branch
+
+Only when user asked to close the Trellis task **and** ship:
+
+1. Code commits first (Steps 4–5 work commits may already be done)
+2. `python3 ./.trellis/scripts/task.py archive <task-dir-or-name>`
+3. `python3 ./.trellis/scripts/add_session.py --title "..." --commit "<work-hashes>" --summary "..."`  
+   - Use **work** commit hashes only (not archive/journal hashes)
+4. `git push` again so archive/journal commits land on the remote branch
+5. If PR already exists, no need to recreate; push updates the PR
+
+If user only wants PR and will archive later, skip this step.
+
+## Step 7: Report
+
+```text
+Branch: <name>
+Commits: <hashes + subjects>
+PR: <url>
+```
+
+## Anti-patterns
+
+- Committing on `main` without user saying so
+- Shipping unrelated dirty files silently
+- Force-push / amend by default
+- Creating a PR with no push
+- Archiving Trellis before code commits when the tree still has task code changes

--- a/.trellis/skills/git-merge-cleanup/SKILL.md
+++ b/.trellis/skills/git-merge-cleanup/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: git-merge-cleanup
+description: "Merge a GitHub PR (or confirm already merged), delete the feature branch, checkout main, and sync local. Use when user says merge the PR, PR merged clean up, switch back to main and delete the feat branch."
+---
+
+# Git Merge + Cleanup
+
+After a feature PR is ready or already merged: merge if needed, delete the feature branch, return local repo to updated `main`.
+
+**Does not** implement features or open PRs. For ship/PR creation use `git-ship-pr`. For Trellis archive/journal use `trellis-finish-work` (usually already done on the feature branch before merge).
+
+## When to use
+
+- User: "merged, switch back to main and delete the feat branch"
+- User: "merge the PR, delete branch, back to main"
+- User: "are you able to merge the pr and clean up"
+
+## Step 1: Identify PR and branch
+
+```bash
+git branch --show-current
+git status --porcelain
+gh pr status
+# or explicit:
+gh pr view <number> --json number,state,mergeable,headRefName,baseRefName,url,title
+```
+
+If user said "merged" without a number, resolve the latest PR for the current branch or the branch they named:
+
+```bash
+gh pr list --head "<branch>" --state all --limit 1
+```
+
+If the working tree is dirty with unrelated changes, warn and ask before `reset --hard` / checkout.
+
+## Step 2: Merge (if still open)
+
+```bash
+gh pr view <n> --json state,mergeable,title,url
+```
+
+| State | Action |
+|-------|--------|
+| `OPEN` + mergeable | `gh pr merge <n> --merge --delete-branch` (or `--squash` if user prefers) |
+| `OPEN` + not mergeable | Report conflicts; stop |
+| `MERGED` | Skip merge; still do local cleanup |
+| `CLOSED` unmerged | Report; do not pretend success |
+
+Default merge method: **merge commit** (`--merge`), matching this repo’s recent PR history. Use `--squash` only if user asks.
+
+`--delete-branch` deletes the **remote** head branch when supported.
+
+## Step 3: Local main sync
+
+```bash
+git fetch --prune origin
+git checkout main
+git pull --ff-only origin main
+```
+
+If pull fails due to ref lock / non-ff:
+
+```bash
+git fetch origin main
+git checkout main
+git reset --hard origin/main
+```
+
+Only use `reset --hard` when the user wants a clean match to remote and there is no precious local-only work on `main`.
+
+## Step 4: Delete local feature branch
+
+```bash
+git branch -d <feature-branch> 2>/dev/null || git branch -D <feature-branch>
+```
+
+- Prefer `-d` (safe). Use `-D` only if branch is unmerged and user confirms discard.
+- If branch already gone (`not found`), continue.
+
+Remote delete if still present and not removed by `gh pr merge --delete-branch`:
+
+```bash
+git push origin --delete <feature-branch> 2>/dev/null || true
+```
+
+"remote ref does not exist" is OK.
+
+## Step 5: Verify
+
+```bash
+git status
+git branch --show-current
+git log --oneline -5
+git branch -a | grep <feature-slug> || echo "feature branch gone"
+```
+
+Expect:
+
+- On `main`
+- Clean working tree (unless user had other WIP)
+- In sync with `origin/main`
+- Feature branch absent locally (and preferably remotely)
+
+## Step 6: Report
+
+```text
+PR: <url> → MERGED
+Local: main @ <short-hash>
+Branches removed: <name> (local/remote)
+```
+
+Optional: if a parent Trellis task is complete (all children archived), mention they can archive the parent with `task.py archive` — do not auto-archive parents unless user asks.
+
+## Anti-patterns
+
+- Merging without checking `mergeable` / CI when user did not waive checks
+- `reset --hard` with uncommitted user work
+- Deleting `main`
+- Leaving local feature branch after "clean up" when delete was requested
+- Creating a new Trellis task for merge cleanup (simple ops; no task unless user wants one)

--- a/.trellis/skills/git-ship-pr/SKILL.md
+++ b/.trellis/skills/git-ship-pr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: git-ship-pr
+description: "Ship work: ensure feature branch, confirm commit plan, commit, push, open GitHub PR. Use when user says ship, open PR, commit and push, create PR, or 'ok close the task and create PR'."
+---
+
+# Git Ship + Open PR
+
+Turn finished local work into a remote branch and a GitHub pull request.
+
+**Does not** merge the PR or archive Trellis tasks. After merge, use `git-merge-cleanup`. For Trellis archive/journal only, use `trellis-finish-work` (after code is committed).
+
+## When to use
+
+- User asks to commit + push + create PR
+- User says "ok close the task in the same branch and create PR"
+- End of Phase 3.4 when the plan includes shipping, not only local commit
+
+## Preconditions
+
+- User confirmed the commit plan (or explicitly said `ok` / `行` to a presented plan)
+- Quality checks already run when this is a Trellis task (typecheck/tests as applicable)
+- Do **not** commit secrets; do **not** amend/force-push unless user explicitly asks
+
+## Step 1: Inspect git state
+
+```bash
+git status --porcelain
+git branch --show-current
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true
+git log --oneline -5
+git diff --stat
+```
+
+Classify dirty paths:
+
+| Kind | Action |
+|------|--------|
+| This task / this request | Include in commit plan |
+| Unrelated WIP | Exclude; list as "not in commits" |
+| Already clean | Skip commit; still may push + PR if branch is ahead |
+
+## Step 2: Ensure feature branch
+
+If current branch is `main` or `master` (or the default base) **and** there are commits or dirty files to ship:
+
+```bash
+git checkout -b <branch>
+```
+
+Branch naming (prefer project style from recent branches):
+
+- `feat/<short-slug>`
+- `fix/<short-slug>`
+- `refactor/<short-slug>`
+- `chore/<short-slug>`
+
+If already on a feature branch, **keep it** (do not create a nested branch).
+
+If the branch name is wrong for the change set, rename with user agreement:
+
+```bash
+git branch -m <new-name>
+```
+
+## Step 3: Commit plan (one-shot confirmation)
+
+Learn message style from `git log --oneline -5`.
+
+Group files into 1+ logical commits (not one commit per file). Present:
+
+```text
+Branch: <name> (create / already on)
+
+Proposed commits (in order):
+  1. <message>
+     - <file>
+  2. <message>
+     - <file>
+
+Excluded (not this work):
+  - <file>
+
+Reply 'ok' / '行' to execute. Edits or 'manual' to abort.
+```
+
+On rejection / `manual`: stop. Do not invent a second full plan unless the user asks.
+
+If the user already said `ok` to a plan in the previous turn, execute without re-asking.
+
+## Step 4: Commit
+
+For each planned commit:
+
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<message>
+
+<optional body>
+EOF
+)"
+```
+
+Rules:
+
+- No `--amend` unless user explicitly requests
+- No empty commits
+- Prefer HEREDOC for multi-line messages
+- After Trellis archive/journal auto-commits, those are separate commits (see optional Step 6)
+
+## Step 5: Push and create PR
+
+```bash
+git push -u origin HEAD
+```
+
+Then create PR against the base branch (usually `main`):
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet>
+
+## Test plan
+- [ ] <check>
+EOF
+)"
+```
+
+- Title usually matches the primary work commit subject
+- Body: summary + test plan (commands already run + manual checks)
+- Return the PR URL to the user
+
+If `gh` is unavailable, print the compare URL from `git push` remote output and stop.
+
+## Step 6 (optional): Trellis close-out on same branch
+
+Only when user asked to close the Trellis task **and** ship:
+
+1. Code commits first (Steps 4–5 work commits may already be done)
+2. `python3 ./.trellis/scripts/task.py archive <task-dir-or-name>`
+3. `python3 ./.trellis/scripts/add_session.py --title "..." --commit "<work-hashes>" --summary "..."`  
+   - Use **work** commit hashes only (not archive/journal hashes)
+4. `git push` again so archive/journal commits land on the remote branch
+5. If PR already exists, no need to recreate; push updates the PR
+
+If user only wants PR and will archive later, skip this step.
+
+## Step 7: Report
+
+```text
+Branch: <name>
+Commits: <hashes + subjects>
+PR: <url>
+```
+
+## Anti-patterns
+
+- Committing on `main` without user saying so
+- Shipping unrelated dirty files silently
+- Force-push / amend by default
+- Creating a PR with no push
+- Archiving Trellis before code commits when the tree still has task code changes


### PR DESCRIPTION
## Summary
- Add project skills `git-ship-pr` (branch/commit/push/PR) and `git-merge-cleanup` (merge/delete branch/sync main).
- Track under `.agents/skills/`, `.opencode/skills/`, and `.trellis/skills/` with gitignore exceptions for platform dirs.

## Test plan
- [x] Files staged and not ignored
- [ ] Agent can load skills after pull